### PR TITLE
fix error in checking class of features or df argument

### DIFF
--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -185,7 +185,7 @@ create_domino = function(signaling_db, features, ser = NULL, counts = NULL,
     }
 
     # Read in features matrix and calculate differential expression by cluster.
-    if(class(features) == 'character'){
+    if(class(features)[1] == 'character'){
         features = read.csv(features, row.names = 1, check.names = FALSE)
     }
     features = features[, colnames(dom@z_scores)]
@@ -231,7 +231,7 @@ create_domino = function(signaling_db, features, ser = NULL, counts = NULL,
     }
 
     # If present, read in and process df
-    if(class(df) == 'character'){
+    if(class(df)[1] == 'character'){
         df = read.csv(df, skip = 3, header = FALSE, stringsAsFactors = FALSE)
     }
     if(!is.null(df)){


### PR DESCRIPTION
Checking the class of a matrix storing feature or pySENIC motifs with the class() function returns a length 2 vector "matrix" "array" that cannot be compared to 'character' using == without throwing up an error that prevents create_domino from running. The inclusion of [1] to only check the first element of the output of class() allows the lines to accomplish their intended function of checking if the arguments are file paths to read in results.